### PR TITLE
Unicode problem

### DIFF
--- a/src/win_delay_load_hook.cc
+++ b/src/win_delay_load_hook.cc
@@ -31,8 +31,13 @@ static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
     return ret;
   }
   if (event == dliStartProcessing) {
-    node_dll = GetModuleHandle("node.dll");
-    nw_dll = GetModuleHandle("nw.dll");
+    #ifdef UNICODE
+      node_dll = GetModuleHandle(L"node.dll");
+      nw_dll = GetModuleHandle(L"nw.dll");
+    #else
+      node_dll = GetModuleHandle("node.dll");
+      nw_dll = GetModuleHandle("nw.dll");  
+    #endif
     return NULL;
   }
   if (event != dliNotePreLoadLibrary)


### PR DESCRIPTION
when compile any node addon with USE_WCHAR and UNICODE flags it works will in node-gyp module but it fails in nw-gyp and this a quick workaround to fix this problem
