### PR TITLE
fix: configure for msvs 2015

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -173,7 +173,7 @@ function configure (gyp, argv, callback) {
     // disable -T "thin" static archives by default
     variables.standalone_static_library = gyp.opts.thin ? 0 : 1
 
-    if (win) {
+    if (win && vsInfo) {
       process.env['GYP_MSVS_VERSION'] = Math.min(vsInfo.versionYear, 2015)
       process.env['GYP_MSVS_OVERRIDE_PATH'] = vsInfo.path
       defaults['msbuild_toolset'] = vsInfo.toolset


### PR DESCRIPTION
966ca060299ea3a31ccd81b35916ccb26980faed added support for VS 2017/2019, but introduced an error for VS 2015. `createConfigFile` is called without a `vsInfo` for 2015, causing 

```bash
> nw-gyp configure --msvs_version=2015
...
gyp verb build/config.gypi creating config file
gyp ERR! UNCAUGHT EXCEPTION
gyp ERR! stack TypeError: Cannot read property 'versionYear' of undefined
``` 

Fix is to only modify the env for windows if `vsInfo` is supplied